### PR TITLE
Update download_jss_scripts.sh

### DIFF
--- a/download_jss_scripts.sh
+++ b/download_jss_scripts.sh
@@ -80,7 +80,7 @@ exit
 }
 
 ## Run loop to check for passed args on the command line
-while getopts ha:p:s option; do
+while getopts ha:p:s: option; do
 	case "${option}" in
 		a) apiUser=${OPTARG};;
 		p) apiPass=${OPTARG};;


### PR DESCRIPTION
Adding ':' to getopts "s" argument to allow the hostname to be specified at any point of the command. Without the additional ':', this command fails:
bash download_jss_scripts.sh -s https://server:port -a apiuser -p apipass